### PR TITLE
Fix android build and .gitignore

### DIFF
--- a/source/android/.gitignore
+++ b/source/android/.gitignore
@@ -3,9 +3,17 @@
 /local.properties
 /build
 /captures
-.externalNativeBuild
 local.properties
+.idea/
+
+.cxx/
+.externalNativeBuild
 
 /OpenRedPlayerCore/libs/
+/OpenRedPlayerCore/build/
 /OpenRedPlayerCore/.idea/
+
+/OpenRedPreload/build/
+
 /app/release
+/app/build

--- a/source/android/app/build.gradle
+++ b/source/android/app/build.gradle
@@ -120,5 +120,5 @@ dependencies {
     implementation "io.reactivex.rxjava3:rxjava:3.1.8"
     implementation 'io.reactivex.rxjava3:rxandroid:3.0.2'
     implementation 'com.github.tbruyelle:rxpermissions:0.12'
-    implementation 'com.wang.avi:library:2.1.3'
+    implementation 'io.github.maitrungduc1410:AVLoadingIndicatorView:2.1.4'
 }

--- a/source/android/settings.gradle
+++ b/source/android/settings.gradle
@@ -3,7 +3,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        jcenter()
         maven { url 'https://jitpack.io' }
     }
 }
@@ -13,7 +12,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
Fix #44. JCenter is gone so `com.wang.avi:library` is no longer available, switching it to a community fork available on Maven.

A large number of built files are not ignored properly, ignoring them so Git actually works.